### PR TITLE
Update generate_jar.yaml

### DIFF
--- a/.github/workflows/generate_jar.yaml
+++ b/.github/workflows/generate_jar.yaml
@@ -61,7 +61,7 @@ jobs:
           set -e
           pushd ..
           source /home/runner/miniconda3/bin/activate root
-          git clone -b '${{ github.event.inputs.arrow_branch }}' '${{ github.event.inputs.arrow_repo }}'
+          git clone -b '${{ github.event.inputs.arrow_branch }}' '${{ github.event.inputs.arrow_repo }}' arrow
           pip install -e arrow/dev/archery[crossbow] 
           echo GITHUB_WORKSPACE:$GITHUB_WORKSPACE
           echo GITHUB_REPOSITORY: $GITHUB_REPOSITORY


### PR DESCRIPTION
Force the repo to be cloned under "arrow" name

My fork is called `dremio-arrow` which breaks the script if ran as-is